### PR TITLE
PE-523 Add test bundle tag serialization for dart ffi

### DIFF
--- a/lib/src/utils/implementations/bundle_tag_parser_ffi.dart
+++ b/lib/src/utils/implementations/bundle_tag_parser_ffi.dart
@@ -2,4 +2,14 @@ import 'dart:typed_data';
 
 import 'package:arweave/arweave.dart';
 
-Uint8List serializeTags({required List<Tag> tags}) => throw UnimplementedError();
+import '../../utils.dart';
+
+/// ONLY FOR TESTING. WILL NOT PASS BUNDLE VERIFICATION
+Uint8List serializeTags({required List<Tag> tags}) {
+  // TODO: Add avro implementation
+  // This serialzation is onlt meant for testing.
+  // Any bundles created with this will not verify as this is not in the avro schema
+  return Uint8List.fromList(tags
+      .expand((t) => decodeBase64ToBytes(t.name) + decodeBase64ToBytes(t.value))
+      .toList());
+}


### PR DESCRIPTION
Instead of throwing an Unimplemented exception, return Uint8List serialized tags instead of avro. This enables us to run tests with bundles, but these bundles will not pass verification since they are in the wrong format.