### PR TITLE
chore: bump version to 3.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
 name: arweave
 description: ""
-version: 2.0.1
+version: 3.0.0
 environment:
-  sdk: '>=2.13.0 <3.0.0'
+  sdk: ">=2.13.0 <3.0.0"
 
 dependencies:
   cryptography: ^2.0.1
@@ -11,10 +11,9 @@ dependencies:
   jwk: ^0.1.0
   meta: ^1.7.0
   pointycastle: ^3.1.1
-  built_value: ^8.0.6 
+  built_value: ^8.0.6
   js: ^0.6.3
   retry: ^3.1.0
-
 
 dev_dependencies:
   build_runner: ^2.0.4


### PR DESCRIPTION
Bumps the version on `pubspec.yml` to 3.0.0.

Sorry about this extra PR @jdaev but I forgot to bump the version on `pubspec.yml`. Could you help get this merged real quick?