### PR TITLE
PE-4971: generate optional fields if missing

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arweave
 description: ""
-version: 3.8.0
+version: 3.8.1
 environment:
   sdk: ">=3.0.0 <4.0.0"
 publish_to: none

--- a/test/wallets_test.dart
+++ b/test/wallets_test.dart
@@ -102,4 +102,22 @@ void main() {
       'browser': Skip('TODO: implement this test for browser'),
     });
   });
+
+  test('loading wallets with missing dp, dq, and qi will have values generated',
+      () async {
+    final wallet =
+        await Wallet.createWalletFromMnemonic(testArweaveAppWalletMnemonic);
+
+    final jwk = wallet.toJwk();
+
+    jwk.remove('dp');
+    jwk.remove('dq');
+    jwk.remove('qi');
+
+    final wallet2 = Wallet.fromJwk(jwk);
+
+    expect(wallet.toJwk(), equals(wallet2.toJwk()));
+  }, onPlatform: {
+    'browser': Skip('TODO: implement this test for browser'),
+  });
 }


### PR DESCRIPTION
* derives and adds dp, dq, and qi fields to key when generating and when loading wallets