### PR TITLE
fix(api): use the correct port for sandboxed endpoints

### DIFF
--- a/lib/src/api/api.dart
+++ b/lib/src/api/api.dart
@@ -26,6 +26,6 @@ class ArweaveApi {
       Uri.parse('${gatewayUrl.origin}/$endpoint');
 
   Uri _getSandboxedEndpointUri(String txId) => Uri.parse(
-        '${gatewayUrl.scheme}://${getSandboxSubdomain(txId)}.${gatewayUrl.host}/$txId',
+        '${gatewayUrl.scheme}://${getSandboxSubdomain(txId)}.${gatewayUrl.host}:${gatewayUrl.port}/$txId',
       );
 }


### PR DESCRIPTION
fixes https://github.com/ardriveapp/arweave-dart/issues/59