### PR TITLE
fix: tolerate null GraphQL fields in TransactionData parsing

### DIFF
--- a/lib/src/streams/download.dart
+++ b/lib/src/streams/download.dart
@@ -215,16 +215,21 @@ class TransactionData {
   }
 
   void parseData(Map<String, dynamic> jsonData) {
-    anchor = jsonData['anchor'];
+    // `anchor`, `recipient` and `signature` are optional in the GraphQL
+    // schema and gateways return `null` (not `''`) when they are absent.
+    // Coalesce to empty strings so parsing doesn't crash on these
+    // non-nullable fields — on web an unguarded null assignment throws
+    // `type 'JSNull' is not a subtype of type 'String'`.
+    anchor = jsonData['anchor'] ?? '';
     owner = jsonData['owner']['key'];
-    target = jsonData['recipient'];
-    signature = jsonData['signature'];
+    target = jsonData['recipient'] ?? '';
+    signature = jsonData['signature'] ?? '';
     dataSize = int.parse(jsonData['data']['size']);
     isDataItem = jsonData['bundledIn'] != null;
     quantity = int.parse(jsonData['quantity']['winston']);
     reward = int.parse(jsonData['fee']['winston']);
 
-    var downloadedTags = jsonData['tags'];
+    var downloadedTags = jsonData['tags'] ?? [];
     tags = [];
     for (var tag in downloadedTags) {
       tags.add(createTag(tag['name'], tag['value']));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: arweave
 description: ""
-version: 4.0.1
+version: 4.0.2
 
 environment:
   sdk: ">=3.0.0 <4.0.0"

--- a/test/transaction_data_test.dart
+++ b/test/transaction_data_test.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:arweave/arweave.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TransactionData.fromJson', () {
+    Map<String, dynamic> baseJson() => {
+          'owner': {'key': 'owner-key'},
+          'data': {'size': '174771'},
+          'quantity': {'winston': '0'},
+          'fee': {'winston': '0'},
+          'anchor': 'an-anchor',
+          'signature': 'a-signature',
+          'recipient': 'a-recipient',
+          'tags': [
+            {'name': 'Content-Type', 'value': 'application/pdf'},
+          ],
+          'bundledIn': {'id': 'bundle-id'},
+        };
+
+    test('parses a fully-populated transaction', () {
+      final data = TransactionData.fromJson(baseJson());
+
+      expect(data.owner, 'owner-key');
+      expect(data.dataSize, 174771);
+      expect(data.anchor, 'an-anchor');
+      expect(data.signature, 'a-signature');
+      expect(data.target, 'a-recipient');
+      expect(data.isDataItem, isTrue);
+      expect(data.tags, hasLength(1));
+    });
+
+    test('coalesces null anchor/recipient/signature to empty strings', () {
+      // Gateways return `null` (not `''`) for absent optional fields. Before
+      // the fix this threw `type 'JSNull' is not a subtype of type 'String'`
+      // on web.
+      final json = baseJson()
+        ..['anchor'] = null
+        ..['recipient'] = null
+        ..['signature'] = null;
+
+      final data = TransactionData.fromJson(json);
+
+      expect(data.anchor, '');
+      expect(data.target, '');
+      expect(data.signature, '');
+    });
+
+    test('treats a null tags list as empty', () {
+      final json = baseJson()..['tags'] = null;
+
+      final data = TransactionData.fromJson(json);
+
+      expect(data.tags, isEmpty);
+    });
+
+    test('isDataItem is false when bundledIn is null', () {
+      final json = baseJson()..['bundledIn'] = null;
+
+      final data = TransactionData.fromJson(json);
+
+      expect(data.isDataItem, isFalse);
+    });
+
+    test('round-trips a real gateway response with null anchor', () {
+      // Shape returned by turbo-gateway.com for a bundled data item.
+      const body =
+          '{"data":{"transaction":{"owner":{"key":"owner-key"},'
+          '"data":{"size":"174771"},"quantity":{"winston":"0"},'
+          '"fee":{"winston":"0"},"anchor":null,"signature":"sig",'
+          '"recipient":"","bundledIn":{"id":"bundle-id"},"tags":[]}}}';
+
+      final txJson = jsonDecode(body)['data']['transaction'];
+      final data = TransactionData.fromJson(txJson);
+
+      expect(data.anchor, '');
+      expect(data.target, '');
+      expect(data.isDataItem, isTrue);
+      expect(data.dataSize, 174771);
+    });
+  });
+}


### PR DESCRIPTION
## Problem

File downloads crash on web when the gateway's GraphQL response returns `null` for optional transaction fields. The error surfaces as:

```
type 'JSNull' is not a subtype of type 'String'
```

`TransactionData.parseData` assigns `anchor`, `recipient` and `signature` directly into non-nullable `late String` fields. `anchor` and `recipient` are legitimately optional in Arweave, and gateways serialize absent values as `null` (not `''`). On web (dart2js) assigning a `JSNull` to a `String` throws, which aborts the entire `download()` call before any bytes are fetched.

Observed against `turbo-gateway.com`, whose GraphQL returns `anchor: null` for bundled data items (`recipient` came back as `""`, but is nullable on other gateways, as is `signature`). The underlying data is served correctly (HTTP 200, valid CORS) — only the parse step fails.

## Fix

Coalesce the optional string fields (and a null `tags` list) to safe defaults. Empty-string is the semantically correct default — an absent anchor/recipient *is* empty — so verification behavior is unchanged for fields that are present.

The `int.parse` fields (`data.size`, `quantity.winston`, `fee.winston`) are intentionally left untouched: they're required value objects, weren't part of the crash, and guarding them would mask genuinely malformed responses.

## Tests

Adds `test/transaction_data_test.dart` covering a fully-populated parse, the null-coalescing case, null tags, `isDataItem` logic, and a round-trip of the real gateway response shape (`anchor: null`, `recipient: ""`). `dart analyze` clean; all tests pass.

Bumps version to `4.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete transaction responses so missing optional values no longer cause crashes.
  * Defaulted absent tag lists to empty lists for more reliable display and parsing.
  * Updated the package version to **4.0.2**.

* **Tests**
  * Added coverage for complete transaction data, missing optional fields, empty tags, and real gateway response shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->